### PR TITLE
refactor: use siteConfig base URL

### DIFF
--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   const metadata: Metadata = {
-    metadataBase: new URL("https://acme.com"),
+    metadataBase: new URL(siteConfig.baseUrl),
     title: homePage.seo?.title || "Default title",
     description: homePage.seo?.description || "Default description",
     openGraph: {


### PR DESCRIPTION
## Summary
- use configured site base URL for metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b1c0d3c8320a15cbec931c55bb8